### PR TITLE
permit blank To when creating draft email with X-Unsent

### DIFF
--- a/lib/eml-format.js
+++ b/lib/eml-format.js
@@ -292,7 +292,7 @@ emlformat.build = function(data, options, callback) {
       data.headers["To"] = (typeof data.to == "string" ? data.to : emlformat.toEmailAddress(data.to));
     }
 
-    if (!data.headers["To"]) {
+    if (!data.headers["To"] && !data.headers["X-Unsent"]) {
       throw new Error("Missing 'To' e-mail address!");
     }
 


### PR DESCRIPTION
Hi! 👋 
      
Firstly, thanks for your work on this project! 🙂

Today I used [patch-package](https://github.com/ds300/patch-package) to patch `eml-format-goon@0.5.5` for the project I'm working on.

<!-- 🔺️🔺️🔺️ PLEASE REPLACE THIS BLOCK with a description of your problem, and any other relevant context 🔺️🔺️🔺️ -->

Here is the diff that solved my problem:

```diff
diff --git a/node_modules/eml-format-goon/lib/eml-format.js b/node_modules/eml-format-goon/lib/eml-format.js
index 9e3b007..f836526 100644
--- a/node_modules/eml-format-goon/lib/eml-format.js
+++ b/node_modules/eml-format-goon/lib/eml-format.js
@@ -289,7 +289,7 @@ emlformat.build = function(data, options, callback) {
       data.headers["To"] = (typeof data.to == "string" ? data.to : emlformat.toEmailAddress(data.to));
     }
 
-    if (!data.headers["To"]) {
+    if (!data.headers["To"] && !data.headers["X-Unsent"]) {
       throw new Error("Missing 'To' e-mail address!");
     }
 
```

<em>This issue body was [partially generated by patch-package](https://github.com/ds300/patch-package/issues/296).</em>
